### PR TITLE
Allow safely calling fit() multiple times

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased][unreleased]
+### Changed
+- `fit` can be safely called multiple times on the same model instance.

--- a/rpforest/rpforest.py
+++ b/rpforest/rpforest.py
@@ -58,9 +58,6 @@ class RPForest(object):
         - object self
         """
 
-        if self._is_constructed():
-            raise Exception('Tree has already been created.')
-
         if X.shape[0] < 1 or X.shape[1] < 1:
             raise Exception('You must supply a valid 2D array.')
 
@@ -70,6 +67,9 @@ class RPForest(object):
             self._X = X / np.linalg.norm(X, axis=1)[:, np.newaxis]
         else:
             self._X = X
+
+        # Reset the trees list in case of repeated calls to fit
+        self.trees = []
 
         for _ in range(self.no_trees):
             tree = Tree(self.leaf_size, self.dim)

--- a/rpforest/rpforest.py
+++ b/rpforest/rpforest.py
@@ -53,6 +53,9 @@ class RPForest(object):
         - optional boolean normalise: whether to normalise X. If True,
                                       a copy of X will be made and
                                       normalised.
+
+        Returns:
+        - object self
         """
 
         if self._is_constructed():
@@ -72,6 +75,8 @@ class RPForest(object):
             tree = Tree(self.leaf_size, self.dim)
             tree.make_tree(self._X)
             self.trees.append(tree)
+
+        return self
 
     def clear(self):
         """

--- a/tests/test_rpforest.py
+++ b/tests/test_rpforest.py
@@ -225,3 +225,17 @@ def test_sample_training():
         precision /= X_test.shape[0]
 
         assert precision >= expected_precision
+
+
+def test_multiple_fit_calls():
+
+    X_train, X_test = _get_mnist_data()
+
+    tree = RPForest(leaf_size=10, no_trees=10)
+    tree.fit(X_train)
+
+    assert len(tree.trees) == 10
+
+    tree.fit(X_train)
+
+    assert len(tree.trees) == 10


### PR DESCRIPTION
Since sklearn in general allows multiple calls to `fit` on the same model instance, let's allow this here too for consistency.